### PR TITLE
Fix the compilation of AES class

### DIFF
--- a/AES.cpp
+++ b/AES.cpp
@@ -1,6 +1,6 @@
 #include "AES.h"
 
-AES::AES(int keyLen = 256)
+AES::AES(int keyLen)
 {
   this->Nb = 4;
   switch (keyLen)

--- a/AES.h
+++ b/AES.h
@@ -55,7 +55,7 @@ private:
   void XorBlocks(unsigned char *a, unsigned char * b, unsigned char *c, unsigned int len);
 
 public:
-  AES(int keyLen);
+  AES(int keyLen = 256);
 
   unsigned char *EncryptECB(unsigned char in[], unsigned int inLen, unsigned  char key[], unsigned int &outLen);
 


### PR DESCRIPTION
I moved the default argument from the definition to declaration of the constructor of AES. You can read here why you should put default arguments in the declaration of the constructor rather than the definition: https://stackoverflow.com/questions/18313509/default-argument-gcc-vs-clang