### PR TITLE
Fix appending uint to error string

### DIFF
--- a/src/AES.cpp
+++ b/src/AES.cpp
@@ -137,7 +137,7 @@ unsigned char *AES::DecryptCFB(unsigned char in[], unsigned int inLen,
 void AES::CheckLength(unsigned int len) {
   if (len % blockBytesLen != 0) {
     throw std::length_error("Plaintext length must be divisible by " +
-                            blockBytesLen);
+                            std::to_string(blockBytesLen));
   }
 }
 


### PR DESCRIPTION
Adding 'unsigned int' to a string does not append to the string.
