### PR TITLE
Use a reference for VectorToArray

### DIFF
--- a/src/AES.cpp
+++ b/src/AES.cpp
@@ -415,7 +415,7 @@ std::vector<unsigned char> AES::ArrayToVector(unsigned char *a,
   return v;
 }
 
-unsigned char *AES::VectorToArray(std::vector<unsigned char> a) {
+unsigned char *AES::VectorToArray(std::vector<unsigned char> &a) {
   return a.data();
 }
 

--- a/src/AES.h
+++ b/src/AES.h
@@ -59,7 +59,7 @@ class AES {
 
   std::vector<unsigned char> ArrayToVector(unsigned char *a, unsigned int len);
 
-  unsigned char *VectorToArray(std::vector<unsigned char> a);
+  unsigned char *VectorToArray(std::vector<unsigned char> &a);
 
  public:
   explicit AES(AESKeyLength keyLength = AESKeyLength::AES_256);


### PR DESCRIPTION
Because otherwise the vector is copied on the stack (pass by value) and `a.data()` returns an address in stack memory.

When `VectorToArray()` returns, the data at this address can be overwritten at any time.

Using a reference avoids the duplication and returns the address of the original parameter that is still valid in the calling context.