### PR TITLE
Add const qualifiers to input arguments

### DIFF
--- a/src/AES.cpp
+++ b/src/AES.cpp
@@ -138,7 +138,7 @@ unsigned char *AES::DecryptCFB(const unsigned char in[], unsigned int inLen,
   return out;
 }
 
-void AES::CheckLength(const unsigned int len) {
+void AES::CheckLength(unsigned int len) {
   if (len % blockBytesLen != 0) {
     throw std::length_error("Plaintext length must be divisible by " +
                             blockBytesLen);

--- a/src/AES.cpp
+++ b/src/AES.cpp
@@ -1,6 +1,6 @@
 #include "AES.h"
 
-AES::AES(AESKeyLength keyLength) {
+AES::AES(const AESKeyLength keyLength) {
   this->Nb = 4;
   switch (keyLength) {
     case AESKeyLength::AES_128:
@@ -20,8 +20,8 @@ AES::AES(AESKeyLength keyLength) {
   blockBytesLen = 4 * this->Nb * sizeof(unsigned char);
 }
 
-unsigned char *AES::EncryptECB(unsigned char in[], unsigned int inLen,
-                               unsigned char key[]) {
+unsigned char *AES::EncryptECB(const unsigned char in[], unsigned int inLen,
+                               const unsigned char key[]) {
   CheckLength(inLen);
   unsigned char *out = new unsigned char[inLen];
   unsigned char *roundKeys = new unsigned char[4 * Nb * (Nr + 1)];
@@ -35,8 +35,8 @@ unsigned char *AES::EncryptECB(unsigned char in[], unsigned int inLen,
   return out;
 }
 
-unsigned char *AES::DecryptECB(unsigned char in[], unsigned int inLen,
-                               unsigned char key[]) {
+unsigned char *AES::DecryptECB(const unsigned char in[], unsigned int inLen,
+                               const unsigned char key[]) {
   CheckLength(inLen);
   unsigned char *out = new unsigned char[inLen];
   unsigned char *roundKeys = new unsigned char[4 * Nb * (Nr + 1)];
@@ -50,8 +50,8 @@ unsigned char *AES::DecryptECB(unsigned char in[], unsigned int inLen,
   return out;
 }
 
-unsigned char *AES::EncryptCBC(unsigned char in[], unsigned int inLen,
-                               unsigned char key[], unsigned char *iv) {
+unsigned char *AES::EncryptCBC(const unsigned char in[], unsigned int inLen,
+                               const unsigned char key[], unsigned char *iv) {
   CheckLength(inLen);
   unsigned char *out = new unsigned char[inLen];
   unsigned char *block = new unsigned char[blockBytesLen];
@@ -70,8 +70,8 @@ unsigned char *AES::EncryptCBC(unsigned char in[], unsigned int inLen,
   return out;
 }
 
-unsigned char *AES::DecryptCBC(unsigned char in[], unsigned int inLen,
-                               unsigned char key[], unsigned char *iv) {
+unsigned char *AES::DecryptCBC(const unsigned char in[], unsigned int inLen,
+                               const unsigned char key[], unsigned char *iv) {
   CheckLength(inLen);
   unsigned char *out = new unsigned char[inLen];
   unsigned char *block = new unsigned char[blockBytesLen];
@@ -90,8 +90,8 @@ unsigned char *AES::DecryptCBC(unsigned char in[], unsigned int inLen,
   return out;
 }
 
-unsigned char *AES::EncryptCFB(unsigned char in[], unsigned int inLen,
-                               unsigned char key[], unsigned char *iv) {
+unsigned char *AES::EncryptCFB(const unsigned char in[], unsigned int inLen,
+                               const unsigned char key[], unsigned char *iv) {
   CheckLength(inLen);
   unsigned char *out = new unsigned char[inLen];
   unsigned char *block = new unsigned char[blockBytesLen];
@@ -112,8 +112,8 @@ unsigned char *AES::EncryptCFB(unsigned char in[], unsigned int inLen,
   return out;
 }
 
-unsigned char *AES::DecryptCFB(unsigned char in[], unsigned int inLen,
-                               unsigned char key[], unsigned char *iv) {
+unsigned char *AES::DecryptCFB(const unsigned char in[], unsigned int inLen,
+                               const unsigned char key[], unsigned char *iv) {
   CheckLength(inLen);
   unsigned char *out = new unsigned char[inLen];
   unsigned char *block = new unsigned char[blockBytesLen];
@@ -134,14 +134,14 @@ unsigned char *AES::DecryptCFB(unsigned char in[], unsigned int inLen,
   return out;
 }
 
-void AES::CheckLength(unsigned int len) {
+void AES::CheckLength(const unsigned int len) {
   if (len % blockBytesLen != 0) {
     throw std::length_error("Plaintext length must be divisible by " +
                             blockBytesLen);
   }
 }
 
-void AES::EncryptBlock(unsigned char in[], unsigned char out[],
+void AES::EncryptBlock(const unsigned char in[], unsigned char out[],
                        unsigned char *roundKeys) {
   unsigned char **state = new unsigned char *[4];
   state[0] = new unsigned char[4 * Nb];
@@ -179,7 +179,7 @@ void AES::EncryptBlock(unsigned char in[], unsigned char out[],
   delete[] state;
 }
 
-void AES::DecryptBlock(unsigned char in[], unsigned char out[],
+void AES::DecryptBlock(const unsigned char in[], unsigned char out[],
                        unsigned char *roundKeys) {
   unsigned char **state = new unsigned char *[4];
   state[0] = new unsigned char[4 * Nb];
@@ -316,7 +316,7 @@ void AES::Rcon(unsigned char *a, int n) {
   a[1] = a[2] = a[3] = 0;
 }
 
-void AES::KeyExpansion(unsigned char key[], unsigned char w[]) {
+void AES::KeyExpansion(const unsigned char key[], unsigned char w[]) {
   unsigned char *temp = new unsigned char[4];
   unsigned char *rcon = new unsigned char[4];
 
@@ -390,8 +390,8 @@ void AES::InvShiftRows(unsigned char **state) {
   ShiftRow(state, 3, Nb - 3);
 }
 
-void AES::XorBlocks(unsigned char *a, unsigned char *b, unsigned char *c,
-                    unsigned int len) {
+void AES::XorBlocks(const unsigned char *a, const unsigned char *b,
+                    unsigned char *c, unsigned int len) {
   for (unsigned int i = 0; i < len; i++) {
     c[i] = a[i] ^ b[i];
   }

--- a/src/AES.cpp
+++ b/src/AES.cpp
@@ -51,7 +51,7 @@ unsigned char *AES::DecryptECB(const unsigned char in[], unsigned int inLen,
 }
 
 unsigned char *AES::EncryptCBC(const unsigned char in[], unsigned int inLen,
-                               const unsigned char key[], unsigned char *iv) {
+                               const unsigned char key[], const unsigned char *iv) {
   CheckLength(inLen);
   unsigned char *out = new unsigned char[inLen];
   unsigned char *block = new unsigned char[blockBytesLen];
@@ -71,7 +71,7 @@ unsigned char *AES::EncryptCBC(const unsigned char in[], unsigned int inLen,
 }
 
 unsigned char *AES::DecryptCBC(const unsigned char in[], unsigned int inLen,
-                               const unsigned char key[], unsigned char *iv) {
+                               const unsigned char key[], const unsigned char *iv) {
   CheckLength(inLen);
   unsigned char *out = new unsigned char[inLen];
   unsigned char *block = new unsigned char[blockBytesLen];
@@ -91,7 +91,7 @@ unsigned char *AES::DecryptCBC(const unsigned char in[], unsigned int inLen,
 }
 
 unsigned char *AES::EncryptCFB(const unsigned char in[], unsigned int inLen,
-                               const unsigned char key[], unsigned char *iv) {
+                               const unsigned char key[], const unsigned char *iv) {
   CheckLength(inLen);
   unsigned char *out = new unsigned char[inLen];
   unsigned char *block = new unsigned char[blockBytesLen];
@@ -113,7 +113,7 @@ unsigned char *AES::EncryptCFB(const unsigned char in[], unsigned int inLen,
 }
 
 unsigned char *AES::DecryptCFB(const unsigned char in[], unsigned int inLen,
-                               const unsigned char key[], unsigned char *iv) {
+                               const unsigned char key[], const unsigned char *iv) {
   CheckLength(inLen);
   unsigned char *out = new unsigned char[inLen];
   unsigned char *block = new unsigned char[blockBytesLen];

--- a/src/AES.cpp
+++ b/src/AES.cpp
@@ -51,7 +51,8 @@ unsigned char *AES::DecryptECB(const unsigned char in[], unsigned int inLen,
 }
 
 unsigned char *AES::EncryptCBC(const unsigned char in[], unsigned int inLen,
-                               const unsigned char key[], const unsigned char *iv) {
+                               const unsigned char key[],
+                               const unsigned char *iv) {
   CheckLength(inLen);
   unsigned char *out = new unsigned char[inLen];
   unsigned char *block = new unsigned char[blockBytesLen];
@@ -71,7 +72,8 @@ unsigned char *AES::EncryptCBC(const unsigned char in[], unsigned int inLen,
 }
 
 unsigned char *AES::DecryptCBC(const unsigned char in[], unsigned int inLen,
-                               const unsigned char key[], const unsigned char *iv) {
+                               const unsigned char key[],
+                               const unsigned char *iv) {
   CheckLength(inLen);
   unsigned char *out = new unsigned char[inLen];
   unsigned char *block = new unsigned char[blockBytesLen];
@@ -91,7 +93,8 @@ unsigned char *AES::DecryptCBC(const unsigned char in[], unsigned int inLen,
 }
 
 unsigned char *AES::EncryptCFB(const unsigned char in[], unsigned int inLen,
-                               const unsigned char key[], const unsigned char *iv) {
+                               const unsigned char key[],
+                               const unsigned char *iv) {
   CheckLength(inLen);
   unsigned char *out = new unsigned char[inLen];
   unsigned char *block = new unsigned char[blockBytesLen];
@@ -113,7 +116,8 @@ unsigned char *AES::EncryptCFB(const unsigned char in[], unsigned int inLen,
 }
 
 unsigned char *AES::DecryptCFB(const unsigned char in[], unsigned int inLen,
-                               const unsigned char key[], const unsigned char *iv) {
+                               const unsigned char key[],
+                               const unsigned char *iv) {
   CheckLength(inLen);
   unsigned char *out = new unsigned char[inLen];
   unsigned char *block = new unsigned char[blockBytesLen];

--- a/src/AES.h
+++ b/src/AES.h
@@ -71,16 +71,16 @@ class AES {
                             const unsigned char key[]);
 
   unsigned char *EncryptCBC(const unsigned char in[], unsigned int inLen,
-                            const unsigned char key[], unsigned char *iv);
+                            const unsigned char key[], const unsigned char *iv);
 
   unsigned char *DecryptCBC(const unsigned char in[], unsigned int inLen,
-                            const unsigned char key[], unsigned char *iv);
+                            const unsigned char key[], const unsigned char *iv);
 
   unsigned char *EncryptCFB(const unsigned char in[], unsigned int inLen,
-                            const unsigned char key[], unsigned char *iv);
+                            const unsigned char key[], const unsigned char *iv);
 
   unsigned char *DecryptCFB(const unsigned char in[], unsigned int inLen,
-                            const unsigned char key[], unsigned char *iv);
+                            const unsigned char key[], const unsigned char *iv);
 
   std::vector<unsigned char> EncryptECB(std::vector<unsigned char> in,
                                         std::vector<unsigned char> key);

--- a/src/AES.h
+++ b/src/AES.h
@@ -46,41 +46,41 @@ class AES {
 
   void CheckLength(unsigned int len);
 
-  void KeyExpansion(unsigned char key[], unsigned char w[]);
+  void KeyExpansion(const unsigned char key[], unsigned char w[]);
 
-  void EncryptBlock(unsigned char in[], unsigned char out[],
+  void EncryptBlock(const unsigned char in[], unsigned char out[],
                     unsigned char key[]);
 
-  void DecryptBlock(unsigned char in[], unsigned char out[],
+  void DecryptBlock(const unsigned char in[], unsigned char out[],
                     unsigned char key[]);
 
-  void XorBlocks(unsigned char *a, unsigned char *b, unsigned char *c,
-                 unsigned int len);
+  void XorBlocks(const unsigned char *a, const unsigned char *b,
+                 unsigned char *c, unsigned int len);
 
   std::vector<unsigned char> ArrayToVector(unsigned char *a, unsigned int len);
 
   unsigned char *VectorToArray(std::vector<unsigned char> a);
 
  public:
-  explicit AES(AESKeyLength keyLength = AESKeyLength::AES_256);
+  explicit AES(const AESKeyLength keyLength = AESKeyLength::AES_256);
 
-  unsigned char *EncryptECB(unsigned char in[], unsigned int inLen,
-                            unsigned char key[]);
+  unsigned char *EncryptECB(const unsigned char in[], unsigned int inLen,
+                            const unsigned char key[]);
 
-  unsigned char *DecryptECB(unsigned char in[], unsigned int inLen,
-                            unsigned char key[]);
+  unsigned char *DecryptECB(const unsigned char in[], unsigned int inLen,
+                            const unsigned char key[]);
 
-  unsigned char *EncryptCBC(unsigned char in[], unsigned int inLen,
-                            unsigned char key[], unsigned char *iv);
+  unsigned char *EncryptCBC(const unsigned char in[], unsigned int inLen,
+                            const unsigned char key[], unsigned char *iv);
 
-  unsigned char *DecryptCBC(unsigned char in[], unsigned int inLen,
-                            unsigned char key[], unsigned char *iv);
+  unsigned char *DecryptCBC(const unsigned char in[], unsigned int inLen,
+                            const unsigned char key[], unsigned char *iv);
 
-  unsigned char *EncryptCFB(unsigned char in[], unsigned int inLen,
-                            unsigned char key[], unsigned char *iv);
+  unsigned char *EncryptCFB(const unsigned char in[], unsigned int inLen,
+                            const unsigned char key[], unsigned char *iv);
 
-  unsigned char *DecryptCFB(unsigned char in[], unsigned int inLen,
-                            unsigned char key[], unsigned char *iv);
+  unsigned char *DecryptCFB(const unsigned char in[], unsigned int inLen,
+                            const unsigned char key[], unsigned char *iv);
 
   std::vector<unsigned char> EncryptECB(std::vector<unsigned char> in,
                                         std::vector<unsigned char> key);


### PR DESCRIPTION
To make clear which arguments are changed and which are guaranteed to remain as they are.

This also prevents unintentionally changing something that should be immutable.