### PR TITLE
Optimizations: Reduced heap allocations

### DIFF
--- a/src/AES.cpp
+++ b/src/AES.cpp
@@ -139,7 +139,7 @@ void AES::CheckLength(unsigned int len) {
 void AES::EncryptBlock(const unsigned char in[], unsigned char out[],
                        unsigned char *roundKeys) {
   unsigned char state[4][Nb];
-  int i, j, round;
+  unsigned int i, j, round;
 
   for (i = 0; i < 4; i++) {
     for (j = 0; j < Nb; j++) {
@@ -170,7 +170,7 @@ void AES::EncryptBlock(const unsigned char in[], unsigned char out[],
 void AES::DecryptBlock(const unsigned char in[], unsigned char out[],
                        unsigned char *roundKeys) {
   unsigned char state[4][Nb];
-  int i, j, round;
+  unsigned int i, j, round;
 
   for (i = 0; i < 4; i++) {
     for (j = 0; j < Nb; j++) {
@@ -199,7 +199,7 @@ void AES::DecryptBlock(const unsigned char in[], unsigned char out[],
 }
 
 void AES::SubBytes(unsigned char state[4][Nb]) {
-  int i, j;
+  unsigned int i, j;
   unsigned char t;
   for (i = 0; i < 4; i++) {
     for (j = 0; j < Nb; j++) {
@@ -209,11 +209,11 @@ void AES::SubBytes(unsigned char state[4][Nb]) {
   }
 }
 
-void AES::ShiftRow(unsigned char state[4][Nb], int i,
-                   int n)  // shift row i on n positions
+void AES::ShiftRow(unsigned char state[4][Nb], unsigned int i,
+                   unsigned int n)  // shift row i on n positions
 {
   unsigned char tmp[Nb];
-  for (int j = 0; j < Nb; j++) {
+  for (unsigned int j = 0; j < Nb; j++) {
     tmp[j] = state[i][(j + n) % Nb];
   }
   memcpy(state[i], tmp, Nb * sizeof(unsigned char));
@@ -254,7 +254,7 @@ void AES::MixColumns(unsigned char state[4][Nb]) {
 }
 
 void AES::AddRoundKey(unsigned char state[4][Nb], unsigned char *key) {
-  int i, j;
+  unsigned int i, j;
   for (i = 0; i < 4; i++) {
     for (j = 0; j < Nb; j++) {
       state[i][j] = state[i][j] ^ key[i + 4 * j];
@@ -284,8 +284,8 @@ void AES::XorWords(unsigned char *a, unsigned char *b, unsigned char *c) {
   }
 }
 
-void AES::Rcon(unsigned char *a, int n) {
-  int i;
+void AES::Rcon(unsigned char *a, unsigned int n) {
+  unsigned int i;
   unsigned char c = 1;
   for (i = 0; i < n - 1; i++) {
     c = xtime(c);
@@ -299,7 +299,7 @@ void AES::KeyExpansion(const unsigned char key[], unsigned char w[]) {
   unsigned char temp[4];
   unsigned char rcon[4];
 
-  int i = 0;
+  unsigned int i = 0;
   while (i < 4 * Nk) {
     w[i] = key[i];
     i++;
@@ -330,7 +330,7 @@ void AES::KeyExpansion(const unsigned char key[], unsigned char w[]) {
 }
 
 void AES::InvSubBytes(unsigned char state[4][Nb]) {
-  int i, j;
+  unsigned int i, j;
   unsigned char t;
   for (i = 0; i < 4; i++) {
     for (j = 0; j < Nb; j++) {

--- a/src/AES.cpp
+++ b/src/AES.cpp
@@ -52,7 +52,7 @@ unsigned char *AES::EncryptCBC(const unsigned char in[], unsigned int inLen,
                                const unsigned char *iv) {
   CheckLength(inLen);
   unsigned char *out = new unsigned char[inLen];
-  unsigned char *block = new unsigned char[blockBytesLen];
+  unsigned char block[blockBytesLen];
   unsigned char *roundKeys = new unsigned char[4 * Nb * (Nr + 1)];
   KeyExpansion(key, roundKeys);
   memcpy(block, iv, blockBytesLen);
@@ -62,7 +62,6 @@ unsigned char *AES::EncryptCBC(const unsigned char in[], unsigned int inLen,
     memcpy(block, out + i, blockBytesLen);
   }
 
-  delete[] block;
   delete[] roundKeys;
 
   return out;
@@ -73,7 +72,7 @@ unsigned char *AES::DecryptCBC(const unsigned char in[], unsigned int inLen,
                                const unsigned char *iv) {
   CheckLength(inLen);
   unsigned char *out = new unsigned char[inLen];
-  unsigned char *block = new unsigned char[blockBytesLen];
+  unsigned char block[blockBytesLen];
   unsigned char *roundKeys = new unsigned char[4 * Nb * (Nr + 1)];
   KeyExpansion(key, roundKeys);
   memcpy(block, iv, blockBytesLen);
@@ -83,7 +82,6 @@ unsigned char *AES::DecryptCBC(const unsigned char in[], unsigned int inLen,
     memcpy(block, in + i, blockBytesLen);
   }
 
-  delete[] block;
   delete[] roundKeys;
 
   return out;
@@ -94,8 +92,8 @@ unsigned char *AES::EncryptCFB(const unsigned char in[], unsigned int inLen,
                                const unsigned char *iv) {
   CheckLength(inLen);
   unsigned char *out = new unsigned char[inLen];
-  unsigned char *block = new unsigned char[blockBytesLen];
-  unsigned char *encryptedBlock = new unsigned char[blockBytesLen];
+  unsigned char block[blockBytesLen];
+  unsigned char encryptedBlock[blockBytesLen];
   unsigned char *roundKeys = new unsigned char[4 * Nb * (Nr + 1)];
   KeyExpansion(key, roundKeys);
   memcpy(block, iv, blockBytesLen);
@@ -105,8 +103,6 @@ unsigned char *AES::EncryptCFB(const unsigned char in[], unsigned int inLen,
     memcpy(block, out + i, blockBytesLen);
   }
 
-  delete[] block;
-  delete[] encryptedBlock;
   delete[] roundKeys;
 
   return out;
@@ -117,8 +113,8 @@ unsigned char *AES::DecryptCFB(const unsigned char in[], unsigned int inLen,
                                const unsigned char *iv) {
   CheckLength(inLen);
   unsigned char *out = new unsigned char[inLen];
-  unsigned char *block = new unsigned char[blockBytesLen];
-  unsigned char *encryptedBlock = new unsigned char[blockBytesLen];
+  unsigned char block[blockBytesLen];
+  unsigned char encryptedBlock[blockBytesLen];
   unsigned char *roundKeys = new unsigned char[4 * Nb * (Nr + 1)];
   KeyExpansion(key, roundKeys);
   memcpy(block, iv, blockBytesLen);
@@ -128,8 +124,6 @@ unsigned char *AES::DecryptCFB(const unsigned char in[], unsigned int inLen,
     memcpy(block, in + i, blockBytesLen);
   }
 
-  delete[] block;
-  delete[] encryptedBlock;
   delete[] roundKeys;
 
   return out;

--- a/src/AES.cpp
+++ b/src/AES.cpp
@@ -218,13 +218,11 @@ void AES::SubBytes(unsigned char state[4][Nb]) {
 void AES::ShiftRow(unsigned char state[4][Nb], int i,
                    int n)  // shift row i on n positions
 {
-  unsigned char *tmp = new unsigned char[Nb];
+  unsigned char tmp[Nb];
   for (int j = 0; j < Nb; j++) {
     tmp[j] = state[i][(j + n) % Nb];
   }
   memcpy(state[i], tmp, Nb * sizeof(unsigned char));
-
-  delete[] tmp;
 }
 
 void AES::ShiftRows(unsigned char state[4][Nb]) {

--- a/src/AES.cpp
+++ b/src/AES.cpp
@@ -302,8 +302,8 @@ void AES::Rcon(unsigned char *a, int n) {
 }
 
 void AES::KeyExpansion(const unsigned char key[], unsigned char w[]) {
-  unsigned char *temp = new unsigned char[4];
-  unsigned char *rcon = new unsigned char[4];
+  unsigned char temp[4];
+  unsigned char rcon[4];
 
   int i = 0;
   while (i < 4 * Nk) {
@@ -333,9 +333,6 @@ void AES::KeyExpansion(const unsigned char key[], unsigned char w[]) {
     w[i + 3] = w[i + 3 - 4 * Nk] ^ temp[3];
     i += 4;
   }
-
-  delete[] rcon;
-  delete[] temp;
 }
 
 void AES::InvSubBytes(unsigned char state[4][Nb]) {

--- a/src/AES.h
+++ b/src/AES.h
@@ -11,24 +11,24 @@ enum class AESKeyLength { AES_128, AES_192, AES_256 };
 
 class AES {
  private:
-  int Nb;
+  static constexpr unsigned int Nb = 4;
+  static constexpr unsigned int blockBytesLen = 4 * Nb * sizeof(unsigned char);
+
   int Nk;
   int Nr;
 
-  unsigned int blockBytesLen;
+  void SubBytes(unsigned char state[4][Nb]);
 
-  void SubBytes(unsigned char **state);
-
-  void ShiftRow(unsigned char **state, int i,
+  void ShiftRow(unsigned char state[4][Nb], int i,
                 int n);  // shift row i on n positions
 
-  void ShiftRows(unsigned char **state);
+  void ShiftRows(unsigned char state[4][Nb]);
 
   unsigned char xtime(unsigned char b);  // multiply on x
 
-  void MixColumns(unsigned char **state);
+  void MixColumns(unsigned char state[4][Nb]);
 
-  void AddRoundKey(unsigned char **state, unsigned char *key);
+  void AddRoundKey(unsigned char state[4][Nb], unsigned char *key);
 
   void SubWord(unsigned char *a);
 
@@ -38,11 +38,11 @@ class AES {
 
   void Rcon(unsigned char *a, int n);
 
-  void InvSubBytes(unsigned char **state);
+  void InvSubBytes(unsigned char state[4][Nb]);
 
-  void InvMixColumns(unsigned char **state);
+  void InvMixColumns(unsigned char state[4][Nb]);
 
-  void InvShiftRows(unsigned char **state);
+  void InvShiftRows(unsigned char state[4][Nb]);
 
   void CheckLength(unsigned int len);
 

--- a/src/AES.h
+++ b/src/AES.h
@@ -14,13 +14,13 @@ class AES {
   static constexpr unsigned int Nb = 4;
   static constexpr unsigned int blockBytesLen = 4 * Nb * sizeof(unsigned char);
 
-  int Nk;
-  int Nr;
+  unsigned int Nk;
+  unsigned int Nr;
 
   void SubBytes(unsigned char state[4][Nb]);
 
-  void ShiftRow(unsigned char state[4][Nb], int i,
-                int n);  // shift row i on n positions
+  void ShiftRow(unsigned char state[4][Nb], unsigned int i,
+                unsigned int n);  // shift row i on n positions
 
   void ShiftRows(unsigned char state[4][Nb]);
 
@@ -36,7 +36,7 @@ class AES {
 
   void XorWords(unsigned char *a, unsigned char *b, unsigned char *c);
 
-  void Rcon(unsigned char *a, int n);
+  void Rcon(unsigned char *a, unsigned int n);
 
   void InvSubBytes(unsigned char state[4][Nb]);
 


### PR DESCRIPTION
I moved every movable arrays that is allocated in heap to the stack,
this optimization speeds up the speed test program in my machine from 1.09 Mb/s to 1.72 Mb/s on average.

These arrays are as follows:

- ~~roundKeys - the round key array at maximum (AES256) can hold up to 240 bytes of **fixed size** data, so we can move this on stack.~~

- `state` - the 4x4 state matrix also has a fixed size, so we can move this on the stack too.

- The `temp` array on `ShiftRow` function is also moved to stack, previously this array has the same size as the `Nb` member, but `Nb` always evaluate to a fix value of `4` so there will be no problem here.

- The `temp` & `rcon` array in `KeyExpansion` is also moved to stack since they have a fix value of 4.

- `block` & `encryptedBlock` - these two arrays relies on the `blockBytesLen = 4 * this->Nb * sizeof(unsigned char);`, but this variable will always evaluate to `16` (since `Nb` is always `4` and almost all modern computers have 8 bits for `char` and `unsigned char` that will always have a value of 1 byte) so this can also be moved in stack.

**others**

- Fixed signed and unsigned comparison warnings.

- ~~I also add a -fsanitize=address flag **only** on workflow_build_test recipe, **not** on docker recipes, this should detect memory leaks in the future when pushing commits.~~

