### PR TITLE
Adding CMake as possible build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,18 @@
 cmake_minimum_required(VERSION 2.8)
 project(AES CXX)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
+
+set(MAIN_PROJECT OFF)
+if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(MAIN_PROJECT ON)
+endif()
 
 include_directories(src)
 add_subdirectory(src)
-add_subdirectory(tests)
+
+if (${MAIN_PROJECT})
+    include(CTest)
+    add_subdirectory(tests)
+
+    add_test(AESTest tests/AESTest)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8)
+project(AES CXX)
+set(CMAKE_CXX_STANDARD 11)
+
+include_directories(src)
+add_subdirectory(src)
+add_subdirectory(tests)

--- a/README.md
+++ b/README.md
@@ -47,10 +47,12 @@ This library does not provide any padding because padding is not part of AES sta
 
 # Development:
 
+## Docker
+
 1. `git clone https://github.com/SergeyBel/AES.git`
-1. `docker-compose build`
-1. `docker-compose up -d`
-1. use make commands
+2. `docker-compose build`
+3. `docker-compose up -d`
+4. use make commands
 
 There are four executables in `bin` folder:  
 * `test` - run tests  
@@ -59,6 +61,13 @@ There are four executables in `bin` folder:
 * `speedtest` - performance speed test (main code will be taken from speedtest/main.cpp)
 * `release` - version with optimization (main code will be taken from dev/main.cpp)  
 
+
+## Native
+
+AES supports either Make or CMake as build systems.
+For both, you need to install [`gtest`](https://github.com/google/googletest) before.
+
+### Make
 
 Build commands:  
 * `make build_all` - build all targets
@@ -74,3 +83,37 @@ Build commands:
 * `make speed_test` - run performance speed test
 * `make release` - run `release` version
 * `make clean` - clean `bin` directory
+
+### CMake
+
+#### Build
+```bash
+mkdir build && cd build
+cmake .. && make -j
+```
+
+#### Run tests
+1. Navigate into the `build` directory created in the [Build](#build) section
+2. Run `ctest`
+
+#### Include AES into your CMake projects
+1. Download this repository. It is recommended to create a directory `external` or similar in which external projects
+can be copied. It is further recommended to use gitmodules if you are using git as version control:
+```bash
+mkdir external
+git submodule add https://github.com/SergejBel/AES external/AES
+```
+2. Add AES to your CMake project. Within your root `CMakeLists.txt` add the following code before using AES:
+```cmake
+# your intro...
+
+include_directories(external/AES/src)
+add_subdirectory(external/AES)
+
+# your builds...
+```
+3. Link your builds against AES
+```cmake
+add_executable(your_executable your_executable.cpp)
+target_link_libraries(your_executable PRIVATE AES)
+```

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(AES AES.cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_executable(AESTest tests.cpp)
-target_link_libraries(AESTest PRIVATE AES)
+target_link_libraries(AESTest PRIVATE AES gtest)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(AESTest tests.cpp)
+target_link_libraries(AESTest PRIVATE AES)


### PR DESCRIPTION
Hi.
I think, it would be useful to be able to natively include this library into CMake projects since it is a widely used build system.

Therefore, I have added CMakeLists.txt to build the library and the tests. The tests are only built if the project is considered as "main project". This means, tests are not built if the library is included into other CMake projects.

I have added descriptions on how to build and include the library in the README.

Building using Make/Makefile is not affected.