### PR TITLE
Fix CMake >=4.0 Compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8...4.1)
 
 project(AES CXX)
 
@@ -7,5 +7,3 @@ set(INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 add_library(${PROJECT_NAME} ${SOURCE_FILES})
 target_include_directories(${PROJECT_NAME} PUBLIC ${INCLUDE_DIR})
-
-


### PR DESCRIPTION
Not sure if there is a desire to keep the minimum CMake version super low so I tried not to alter it here.

CMake 4.0 removed support for versions <3.5, affecting builds on GitHub's Mac runner (https://github.com/actions/runner-images/issues/12934, see https://github.com/SuperDude88/TWWHD-Randomizer/actions/runs/17953855729/job/51059974437 for an example of the error). Specifying a maximum version allows CMake to configure with a higher version that is still supported.